### PR TITLE
Board config

### DIFF
--- a/libraries/ICM42688P/examples/example-raw-ag/example-raw-ag.ino
+++ b/libraries/ICM42688P/examples/example-raw-ag/example-raw-ag.ino
@@ -1,15 +1,32 @@
+/*
+ * ICM42688P Processed Accelerometer/Gyroscope Data Example
+ *
+ * This example demonstrates processed accelerometer and gyroscope data acquisition
+ * from the ICM42688P using the InvenSense reference implementation with clock
+ * calibration and advanced data processing.
+ *
+ * HARDWARE CONFIGURATION:
+ * - Uses BoardConfig for automatic board detection (NUCLEO_F411RE / BLACKPILL_F411CE)
+ * - Pin assignments and SPI frequency from board configuration
+ * - Interrupt pin configured for data-ready signaling (PC4/EXTI4)
+ * - Supports multiple board targets with single codebase
+ *
+ * CI/HIL INTEGRATION:
+ * - RTT output for automated testing
+ * - Serial output for Arduino IDE
+ * - Build traceability with git SHA and timestamp
+ */
+
 #include "icm42688p.h"
 #include <ci_log.h>
 #include <SPI.h>
 #include <cstring>
 
-// Board configuration integration
+// Board configuration
 #if defined(ARDUINO_BLACKPILL_F411CE)
 #include "../../../../targets/BLACKPILL_F411CE.h"
-#elif defined(ARDUINO_NUCLEO_F411RE)
-#include "../../../../targets/NUCLEO_F411RE_LITTLEFS.h"
 #else
-#include "../../../../targets/NUCLEO_F411RE_LITTLEFS.h"  // Default fallback
+#include "../../../../targets/NUCLEO_F411RE_LITTLEFS.h"
 #endif
 
 #include "inv_main.h"
@@ -18,24 +35,20 @@
 // libPrintf integration - automatic aliasing enabled
 #include <libPrintf.h>
 
-// Uncomment to use software driven NSS
-#define USE_SOFT_NSS
-#define DESIRED_SPI_FREQ 1000000
-
 // BoardConfig integration for dynamic pin and frequency configuration
 #define IMU_CS_PIN        BoardConfig::imu.spi.cs_pin
 #define IMU_MOSI_PIN      BoardConfig::imu.spi.mosi_pin
 #define IMU_MISO_PIN      BoardConfig::imu.spi.miso_pin
 #define IMU_SCLK_PIN      BoardConfig::imu.spi.sclk_pin
-#define IMU_SPI_SPEED     (BoardConfig::imu.freq_override_hz ? BoardConfig::imu.freq_override_hz : BoardConfig::imu.spi.freq_hz)
+#define IMU_SPI_SPEED     BoardConfig::imu.spi.freq_hz
 #define IMU_INT_PIN       BoardConfig::imu.int_pin
 #define INT1_PIN          IMU_INT_PIN
 
-constexpr bool off = 0;
-constexpr bool on = 1;
-
-// Create SPI instance with BoardConfig pins (software CS control)
-SPIClass spi_bus(IMU_MOSI_PIN, IMU_MISO_PIN, IMU_SCLK_PIN);  // No SSEL = software CS
+// Create SPI instance using BoardConfig (software CS control)
+SPIClass spi_bus(BoardConfig::imu.spi.mosi_pin,
+                 BoardConfig::imu.spi.miso_pin,
+                 BoardConfig::imu.spi.sclk_pin,
+                 BoardConfig::imu.spi.get_ssel_pin());
 
 // UART types for InvenSense compatibility
 typedef enum {

--- a/libraries/ICM42688P/examples/example-raw-ag/system-interface.ino
+++ b/libraries/ICM42688P/examples/example-raw-ag/system-interface.ino
@@ -4,8 +4,8 @@
 
 #include "stm32f4xx_ll_spi.h"
 
-/* Default SPI frequency is 1 Mhz */
-static uint32_t spi_freq_hz_ = IMU_SPI_SPEED;
+/* Default SPI frequency from BoardConfig */
+static uint32_t spi_freq_hz_ = BoardConfig::imu.spi.freq_hz;
 
 #ifdef __cplusplus
 extern "C" {
@@ -130,9 +130,9 @@ void inv_io_hal_configure_spi_speed(uint8_t spi_freq_mhz)
 int inv_io_hal_init(struct inv_icm426xx_serif* serif)
 {
     // Initialize CS pin and save PinName for fast access
-    pinMode(IMU_CS_PIN, OUTPUT);
-    digitalWrite(IMU_CS_PIN, HIGH);
-    cs_pin_ = digitalPinToPinName(IMU_CS_PIN);
+    pinMode(BoardConfig::imu.spi.cs_pin, OUTPUT);
+    digitalWrite(BoardConfig::imu.spi.cs_pin, HIGH);
+    cs_pin_ = digitalPinToPinName(BoardConfig::imu.spi.cs_pin);
 
     // Set DWT ticks per uSec
     usTicks_ = SystemCoreClock / 1'000'000;

--- a/libraries/ICM42688P/examples/example-raw-data-registers/system-interface.ino
+++ b/libraries/ICM42688P/examples/example-raw-data-registers/system-interface.ino
@@ -4,8 +4,8 @@
 
 #include "stm32f4xx_ll_spi.h"
 
-/* Default SPI frequency is 1 Mhz */
-static uint32_t spi_freq_hz_ = IMU_SPI_SPEED;
+/* Default SPI frequency from BoardConfig */
+static uint32_t spi_freq_hz_ = BoardConfig::imu.spi.freq_hz;
 
 #ifdef __cplusplus
 extern "C" {
@@ -130,9 +130,9 @@ void inv_io_hal_configure_spi_speed(uint8_t spi_freq_mhz)
 int inv_io_hal_init(struct inv_icm426xx_serif* serif)
 {
     // Initialize CS pin and save PinName for fast access
-    pinMode(IMU_CS_PIN, OUTPUT);
-    digitalWrite(IMU_CS_PIN, HIGH);
-    cs_pin_ = digitalPinToPinName(IMU_CS_PIN);
+    pinMode(BoardConfig::imu.spi.cs_pin, OUTPUT);
+    digitalWrite(BoardConfig::imu.spi.cs_pin, HIGH);
+    cs_pin_ = digitalPinToPinName(BoardConfig::imu.spi.cs_pin);
 
     // Set DWT ticks per uSec
     usTicks_ = SystemCoreClock / 1'000'000;

--- a/libraries/ICM42688P/examples/example-selftest/system-interface.ino
+++ b/libraries/ICM42688P/examples/example-selftest/system-interface.ino
@@ -4,8 +4,8 @@
 
 #include "stm32f4xx_ll_spi.h"
 
-/* Default SPI frequency is 1 Mhz */
-static uint32_t spi_freq_hz_ = IMU_SPI_SPEED;
+/* Default SPI frequency from BoardConfig */
+static uint32_t spi_freq_hz_ = BoardConfig::imu.spi.freq_hz;
 
 #ifdef __cplusplus
 extern "C" {
@@ -130,9 +130,9 @@ void inv_io_hal_configure_spi_speed(uint8_t spi_freq_mhz)
 int inv_io_hal_init(struct inv_icm426xx_serif* serif)
 {
     // Initialize CS pin and save PinName for fast access
-    pinMode(IMU_CS_PIN, OUTPUT);
-    digitalWrite(IMU_CS_PIN, HIGH);
-    cs_pin_ = digitalPinToPinName(IMU_CS_PIN);
+    pinMode(BoardConfig::imu.spi.cs_pin, OUTPUT);
+    digitalWrite(BoardConfig::imu.spi.cs_pin, HIGH);
+    cs_pin_ = digitalPinToPinName(BoardConfig::imu.spi.cs_pin);
 
     // Set DWT ticks per uSec
     usTicks_ = SystemCoreClock / 1'000'000;

--- a/targets/BLACKPILL_F411CE.h
+++ b/targets/BLACKPILL_F411CE.h
@@ -9,7 +9,7 @@ namespace BoardConfig {
 
   // IMU: SPI connections via jumpers (reduced speed for reliability)
   static constexpr SPIConfig imu_spi{PB15, PB14, PB13, PB12, 1000000};
-  static constexpr IMUConfig imu = IMUConfig::spi_imu(imu_spi, 0, PC13);
+  static constexpr IMUConfig imu{imu_spi, PC13};
 
   // GPS: UART communication
   static constexpr UARTConfig gps{PA2, PA3, 115200};

--- a/targets/HW_CONFIG.md
+++ b/targets/HW_CONFIG.md
@@ -77,6 +77,13 @@ namespace BoardConfig {
     const uint32_t mosi_pin, miso_pin, sclk_pin, cs_pin;
     const uint32_t freq_hz;
     const CS_Mode cs_mode;
+
+    // Helper: Get SSEL pin for SPIClass constructor
+    // SW mode: returns PNUM_NOT_DEFINED (disables hardware SSEL)
+    // HW mode: returns cs_pin (STM32 SPI peripheral controls CS)
+    constexpr uint32_t get_ssel_pin() const {
+      return (cs_mode == CS_Mode::HARDWARE) ? cs_pin : PNUM_NOT_DEFINED;
+    }
   };
 
   struct UARTConfig {
@@ -424,6 +431,30 @@ Adding a new board requires:
 2. **Add configuration** in `targets/boards/NEW_BOARD.h`
 3. **Update selector** in `targets/BoardConfig.h`
 4. **Add boards.txt entry** for Arduino CLI recognition
+
+## Hardware Validation (NUCLEO_F411RE)
+
+**Validated Configuration** (2025-09-30):
+- **Board**: NUCLEO-F411RE + ICM42688P via jumper wires
+- **CS Control**: Software mode (manual digitalWrite)
+- **SPI Speed**: 1MHz (reliable for jumper connections)
+
+**Pin Assignments**:
+```cpp
+// ICM42688P SPI connection (validated)
+CS:   PA4  (Software control via digitalWrite)
+MOSI: PA7  (SPI1_MOSI)
+MISO: PA6  (SPI1_MISO)
+SCLK: PA5  (SPI1_SCK)
+INT:  PC4  (EXTI4 interrupt pin)
+```
+
+**Validation Results**:
+- ✅ **Device Detection**: WHO_AM_I = 0x47 (ICM42688P confirmed)
+- ✅ **SPI Communication**: 5/5 successful register reads
+- ✅ **Software CS**: Manual digitalWrite control working
+- ✅ **BoardConfig Integration**: Hardcoded pins replaced with BoardConfig
+- ✅ **HIL Testing**: Deterministic RTT exit with "*STOP*" wildcard
 
 ### Additional Peripheral Types
 

--- a/targets/NOXE_V3.h
+++ b/targets/NOXE_V3.h
@@ -8,8 +8,9 @@ namespace BoardConfig {
   static constexpr StorageConfig storage{StorageBackend::LITTLEFS, PB15, PB14, PB13, PB12, 8000000};
 
   // IMU: High-performance IMU for flight control
+  // Hardware CS with dual-frequency: 1MHz setup, 8MHz runtime (MPU-6000 pattern)
   static constexpr SPIConfig imu_spi{PA7, PA6, PA5, PA4, 8000000, CS_Mode::HARDWARE};
-  static constexpr IMUConfig imu = IMUConfig::spi_imu(imu_spi, 0, PD2);
+  static constexpr IMUConfig imu{imu_spi, PD2, 1000000};
 
   // GPS: High-precision GPS module
   static constexpr UARTConfig gps{PC6, PC7, 115200};

--- a/targets/NUCLEO_F411RE.h
+++ b/targets/NUCLEO_F411RE.h
@@ -9,8 +9,9 @@ namespace BoardConfig {
   static constexpr StorageConfig storage{StorageBackend::NONE, 0, 0, 0, 0, 0};
 
   // IMU: SPI connections via jumpers (reduced speed for reliability)
+  // Single frequency for development/testing
   static constexpr SPIConfig imu_spi{PA7, PA6, PA5, PA4, 1000000};
-  static constexpr IMUConfig imu = IMUConfig::spi_imu(imu_spi, 0, PC4);
+  static constexpr IMUConfig imu{imu_spi, PC4};
 
   // GPS: UART communication
   static constexpr UARTConfig gps{PA9, PA10, 115200};

--- a/targets/NUCLEO_F411RE_LITTLEFS.h
+++ b/targets/NUCLEO_F411RE_LITTLEFS.h
@@ -12,7 +12,7 @@ namespace BoardConfig {
 
   // IMU: Available SPI pins for sensors (if needed)
   static constexpr SPIConfig imu_spi{PA7, PA6, PA5, PA4, 1000000};
-  static constexpr IMUConfig imu = IMUConfig::spi_imu(imu_spi, 0, PC4);
+  static constexpr IMUConfig imu{imu_spi, PC4};
 
   // GPS: UART communication (if needed)
   static constexpr UARTConfig gps{PA9, PA10, 115200};

--- a/targets/NUCLEO_F411RE_SDFS.h
+++ b/targets/NUCLEO_F411RE_SDFS.h
@@ -12,7 +12,7 @@ namespace BoardConfig {
 
   // IMU: Available SPI pins for sensors (if needed)
   static constexpr SPIConfig imu_spi{PA7, PA6, PA5, PA4, 1000000};
-  static constexpr IMUConfig imu = IMUConfig::spi_imu(imu_spi, 0, PC4);
+  static constexpr IMUConfig imu{imu_spi, PC4};
 
   // GPS: UART communication (if needed)
   static constexpr UARTConfig gps{PA9, PA10, 115200};


### PR DESCRIPTION
This pull request delivers a major refactor and documentation update to unify board configuration and peripheral initialization across all ICM42688P IMU examples and the main documentation. The changes introduce a comprehensive, composable board configuration system, streamline SPI and interrupt setup, and ensure all hardware abstraction is driven by a single `BoardConfig` interface. This enables seamless support for multiple STM32 boards, simplifies example code, and improves maintainability and testability across the codebase.

**Key changes by theme:**

### Board Configuration and Hardware Abstraction

- Introduced a comprehensive compile-time `BoardConfig` system supporting multiple boards (NUCLEO_F411RE, BLACKPILL_F411CE, NOXE_V3), flexible peripheral configuration, hardware/software chip select control, and union-based SPI/I2C transport abstraction. All IMU and storage configuration is now centralized and composable, with helper functions for SSEL pin selection and interrupt support.
- Updated all ICM42688P IMU examples (`example-minimal`, `example-raw-ag`, `example-raw-data-registers`) to use `BoardConfig` for SPI pin assignments, frequency, and interrupt pin configuration, removing hardcoded pin definitions and redundant macros. SPI initialization now uses the `get_ssel_pin()` helper for correct hardware/software CS handling. [[1]](diffhunk://#diff-1dca4e2ae953872fd04187ad51c4291be935a308d2411f47a9b21fad2d8511a3L5-R20) [[2]](diffhunk://#diff-1dca4e2ae953872fd04187ad51c4291be935a308d2411f47a9b21fad2d8511a3L36-R47) [[3]](diffhunk://#diff-126d8384ab63d53c6de783089334ee6aabc3d34ffa4ff987d68240d43be547ceR1-R29) [[4]](diffhunk://#diff-126d8384ab63d53c6de783089334ee6aabc3d34ffa4ff987d68240d43be547ceL21-R51) [[5]](diffhunk://#diff-71de87a39bdc837e86d11386783f2039a122ad2cb75407926c936dc1ad974ef8R1-R28) [[6]](diffhunk://#diff-71de87a39bdc837e86d11386783f2039a122ad2cb75407926c936dc1ad974ef8L21-R50)

### Example and System Interface Refactoring

- Refactored all system interface and initialization code in IMU examples to use `BoardConfig` fields for SPI frequency and CS pin setup, ensuring consistent and correct hardware initialization for all supported boards. [[1]](diffhunk://#diff-2e3f76cd790a6004e1f326439f063665e0f3d1f3534940902c81e1fa1982747dL7-R8) [[2]](diffhunk://#diff-2e3f76cd790a6004e1f326439f063665e0f3d1f3534940902c81e1fa1982747dL133-R135)
- Updated example documentation blocks to clarify hardware configuration, board auto-detection, and CI/HIL integration, making it easier for users to understand and adapt examples for different targets. [[1]](diffhunk://#diff-126d8384ab63d53c6de783089334ee6aabc3d34ffa4ff987d68240d43be547ceR1-R29) [[2]](diffhunk://#diff-71de87a39bdc837e86d11386783f2039a122ad2cb75407926c936dc1ad974ef8R1-R28)

### Documentation and Library Updates

- Rewrote and expanded the main `CLAUDE.md` documentation to reflect the new board configuration system, improved storage abstraction, and simplified usage for both storage and printf libraries. Outdated or redundant sections were removed or consolidated for clarity. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L150-L154) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L276-L317) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L351-L528) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R425-R428)

---

**Most important changes:**

#### Board Configuration System
* Introduced a unified, extensible `BoardConfig` system with compile-time board detection, composable SPI/IMU configuration, hardware/software CS control, and interrupt pin support for all supported boards.
* Refactored all IMU examples to use `BoardConfig` for SPI and interrupt configuration, eliminating hardcoded pins and macros, and ensuring consistent initialization across platforms. [[1]](diffhunk://#diff-1dca4e2ae953872fd04187ad51c4291be935a308d2411f47a9b21fad2d8511a3L5-R20) [[2]](diffhunk://#diff-1dca4e2ae953872fd04187ad51c4291be935a308d2411f47a9b21fad2d8511a3L36-R47) [[3]](diffhunk://#diff-126d8384ab63d53c6de783089334ee6aabc3d34ffa4ff987d68240d43be547ceR1-R29) [[4]](diffhunk://#diff-126d8384ab63d53c6de783089334ee6aabc3d34ffa4ff987d68240d43be547ceL21-R51) [[5]](diffhunk://#diff-71de87a39bdc837e86d11386783f2039a122ad2cb75407926c936dc1ad974ef8R1-R28) [[6]](diffhunk://#diff-71de87a39bdc837e86d11386783f2039a122ad2cb75407926c936dc1ad974ef8L21-R50)

#### System Interface and Example Consistency
* Updated system interface code in IMU examples to initialize SPI and CS pins using `BoardConfig`, ensuring proper hardware abstraction and reducing duplication. [[1]](diffhunk://#diff-2e3f76cd790a6004e1f326439f063665e0f3d1f3534940902c81e1fa1982747dL7-R8) [[2]](diffhunk://#diff-2e3f76cd790a6004e1f326439f063665e0f3d1f3534940902c81e1fa1982747dL133-R135)

#### Documentation Improvements
* Rewrote `CLAUDE.md` to document the new board configuration system, updated example usage, and clarified storage and printf library integration, removing obsolete sections and improving overall clarity. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L150-L154) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L276-L317) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L351-L528) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R425-R428)

This refactor greatly simplifies hardware abstraction, improves code maintainability, and ensures all examples and documentation are aligned with the latest best practices for board configuration and peripheral integration.