### PR TITLE
Add IMU library with ICM42688P support and chip detection framework

### DIFF
--- a/libraries/imu/examples/example-selftest/example-selftest.ino
+++ b/libraries/imu/examples/example-selftest/example-selftest.ino
@@ -1,0 +1,143 @@
+/*
+ * IMU Library Self-Test Example
+ *
+ * High-level IMU wrapper demonstrating manufacturer self-test integration with
+ * TDK InvenSense factory algorithms. Uses IMU library for clean abstraction over
+ * hardware-specific details.
+ *
+ * HARDWARE CONFIGURATION:
+ * - Uses BoardConfig for automatic board detection (NUCLEO_F411RE / BLACKPILL_F411CE)
+ * - Pin assignments and SPI frequency from board configuration
+ * - Supports multiple board targets with single codebase
+ *
+ * CI/HIL INTEGRATION:
+ * - RTT output for automated testing
+ * - Serial output for Arduino IDE
+ * - Deterministic exit with "*STOP*" wildcard
+ * - Build traceability with git SHA and timestamp
+ */
+
+#include <IMU.h>
+#include <ci_log.h>
+#include <SPI.h>
+#include <libPrintf.h>
+
+// Board configuration
+#if defined(ARDUINO_BLACKPILL_F411CE)
+#include "../../../../targets/BLACKPILL_F411CE.h"
+#else
+#include "../../../../targets/NUCLEO_F411RE_LITTLEFS.h"
+#endif
+
+// Create SPI instance using BoardConfig (software CS control)
+SPIClass spi_bus(BoardConfig::imu.spi.mosi_pin,
+                 BoardConfig::imu.spi.miso_pin,
+                 BoardConfig::imu.spi.sclk_pin,
+                 BoardConfig::imu.spi.get_ssel_pin());
+
+// Create IMU instance
+IMU imu;
+
+void setup() {
+    // Initialize communication (Serial or RTT)
+#ifndef USE_RTT
+    Serial.begin(115200);
+    while (!Serial) delay(10);
+#endif
+
+    CI_LOG("\n=== IMU Library Self-Test Example ===\n");
+    CI_BUILD_INFO();
+    CI_READY_TOKEN();
+
+    // Display pin configuration
+    CI_LOG("Pin Configuration (BoardConfig):\n");
+    printf("  CS: %d, MOSI: %d, MISO: %d, SCLK: %d\n",
+           (int)BoardConfig::imu.spi.cs_pin,
+           (int)BoardConfig::imu.spi.mosi_pin,
+           (int)BoardConfig::imu.spi.miso_pin,
+           (int)BoardConfig::imu.spi.sclk_pin);
+    printf("  SPI Speed: %lu Hz\n\n", (unsigned long)BoardConfig::imu.spi.freq_hz);
+
+    // Give ICM-42688P some time to stabilize
+    delay(5);
+
+    // Initialize IMU
+    CI_LOG("Initializing IMU...\n");
+    if (imu.Init(spi_bus, BoardConfig::imu.spi.cs_pin, BoardConfig::imu.spi.freq_hz) != IMU::Result::OK) {
+        CI_LOG("ERROR: Failed to initialize IMU!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+    CI_LOG("✓ IMU initialized successfully\n\n");
+
+    // Run self-test
+    CI_LOG("Running manufacturer self-test...\n");
+    CI_LOG("This may take a few seconds...\n\n");
+
+    int result = 0;
+    std::array<int, 6> bias;
+    int rc = imu.RunSelfTest(&result, &bias);
+
+    if (rc != 0) {
+        CI_LOG("ERROR: Self-test failed to execute\n");
+        printf("Return code: %d\n", rc);
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+
+    // Check results
+    bool gyro_pass = (result & 0x01);
+    bool accel_pass = (result & 0x02);
+
+    CI_LOG("=== Self-Test Results ===\n");
+    printf("Gyro Self-Test:  %s\n", gyro_pass ? "PASS" : "FAIL");
+    printf("Accel Self-Test: %s\n\n", accel_pass ? "PASS" : "FAIL");
+
+    if (gyro_pass && accel_pass) {
+        CI_LOG("✓ All self-tests PASSED\n\n");
+    } else {
+        CI_LOG("✗ Self-test FAILED\n\n");
+    }
+
+    // Display bias values (converted to physical units)
+    float gyro_sens = imu.GetGyroSensitivity();
+    float accel_sens = imu.GetAccelSensitivity();
+
+    CI_LOG("=== Bias Values ===\n");
+    printf("Gyro Bias (dps):  x=%.6f, y=%.6f, z=%.6f\n",
+           bias[0] / gyro_sens,
+           bias[1] / gyro_sens,
+           bias[2] / gyro_sens);
+    printf("Accel Bias (g):   x=%.6f, y=%.6f, z=%.6f\n\n",
+           bias[3] / accel_sens,
+           bias[4] / accel_sens,
+           bias[5] / accel_sens);
+
+    CI_LOG("=== Test Complete ===\n");
+    CI_LOG("*STOP*\n");
+}
+
+void loop() {
+    // Nothing to do
+}
+
+/* --------------------------------------------------------------------------------------
+ *  libPrintf putchar_ implementation for RTT/Serial routing
+ * -------------------------------------------------------------------------------------- */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void putchar_(char c) {
+#ifdef USE_RTT
+    char buf[2] = {c, '\0'};
+    SEGGER_RTT_WriteString(0, buf);
+#else
+    Serial.print(c);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/imu/examples/imu-raw-data-registers/imu-raw-data-registers.ino
+++ b/libraries/imu/examples/imu-raw-data-registers/imu-raw-data-registers.ino
@@ -1,0 +1,183 @@
+/*
+ * IMU Library - Interrupt-Driven Raw Data Example
+ *
+ * Demonstrates interrupt-driven raw sensor data acquisition using the IMU library.
+ * Uses data-ready interrupt on INT1 pin to trigger readings when new data is available.
+ *
+ * HARDWARE CONFIGURATION:
+ * - Uses BoardConfig for automatic board detection (NUCLEO_F411RE / BLACKPILL_F411CE)
+ * - Pin assignments and SPI frequency from board configuration
+ * - Interrupt pin configured for data-ready signaling
+ *
+ * CI/HIL INTEGRATION:
+ * - RTT output for automated testing
+ * - Serial output for Arduino IDE
+ * - Deterministic exit with "*STOP*" wildcard
+ * - Build traceability with git SHA and timestamp
+ */
+
+#include <IMU.h>
+#include <ci_log.h>
+#include <SPI.h>
+#include <libPrintf.h>
+
+// Board configuration
+#if defined(ARDUINO_BLACKPILL_F411CE)
+#include "../../../../targets/BLACKPILL_F411CE.h"
+#else
+#include "../../../../targets/NUCLEO_F411RE_LITTLEFS.h"
+#endif
+
+// Create SPI instance using BoardConfig (software CS control)
+SPIClass spi_bus(BoardConfig::imu.spi.mosi_pin,
+                 BoardConfig::imu.spi.miso_pin,
+                 BoardConfig::imu.spi.sclk_pin,
+                 BoardConfig::imu.spi.get_ssel_pin());
+
+// Create IMU instance
+IMU imu;
+
+// Interrupt flag
+volatile bool data_ready = false;
+
+// Interrupt handler
+void imu_data_ready_handler() {
+    data_ready = true;
+}
+
+void setup() {
+    // Initialize communication (Serial or RTT)
+#ifndef USE_RTT
+    Serial.begin(115200);
+    while (!Serial) delay(10);
+#endif
+
+    CI_LOG("\n=== IMU Library - Interrupt-Driven Data Example ===\n");
+    CI_BUILD_INFO();
+    CI_READY_TOKEN();
+
+    // Display pin configuration
+    CI_LOG("Pin Configuration (BoardConfig):\n");
+    printf("  CS: %d, MOSI: %d, MISO: %d, SCLK: %d\n",
+           (int)BoardConfig::imu.spi.cs_pin,
+           (int)BoardConfig::imu.spi.mosi_pin,
+           (int)BoardConfig::imu.spi.miso_pin,
+           (int)BoardConfig::imu.spi.sclk_pin);
+    printf("  SPI Speed: %lu Hz\n", (unsigned long)BoardConfig::imu.spi.freq_hz);
+
+    if (BoardConfig::imu.int_pin != 0) {
+        printf("  Interrupt Pin: %d\n\n", (int)BoardConfig::imu.int_pin);
+    } else {
+        CI_LOG("  Interrupt Pin: None configured\n");
+        CI_LOG("ERROR: This example requires interrupt pin!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+
+    // Give IMU time to stabilize
+    delay(5);
+
+    // Initialize IMU
+    CI_LOG("Initializing IMU...\n");
+    if (imu.Init(spi_bus, BoardConfig::imu.spi.cs_pin, BoardConfig::imu.spi.freq_hz) != IMU::Result::OK) {
+        CI_LOG("ERROR: Failed to initialize IMU!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+    CI_LOG("✓ IMU initialized successfully\n\n");
+
+    // Configure IMU for interrupt-driven operation
+    CI_LOG("Configuring IMU...\n");
+
+    // Set accelerometer and gyro to low noise mode
+    if (imu.EnableAccelLNMode() != 0 || imu.EnableGyroLNMode() != 0) {
+        CI_LOG("ERROR: Failed to enable sensors!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+
+    // Set sample rates (1kHz for both)
+    if (imu.SetAccelODR(IMU::AccelODR::accel_odr1k) != 0 ||
+        imu.SetGyroODR(IMU::GyroODR::gyr_odr1k) != 0) {
+        CI_LOG("ERROR: Failed to set ODR!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+
+    // Configure interrupt pin
+    pinMode(BoardConfig::imu.int_pin, INPUT);
+    attachInterrupt(digitalPinToInterrupt(BoardConfig::imu.int_pin),
+                    imu_data_ready_handler, RISING);
+
+    // Enable data ready interrupt on INT1
+    if (imu.EnableDataReadyInt1() != 0) {
+        CI_LOG("ERROR: Failed to enable data ready interrupt!\n");
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+
+    CI_LOG("✓ IMU configured for interrupt-driven operation\n");
+    CI_LOG("  Accel ODR: 1kHz, Gyro ODR: 1kHz\n");
+    CI_LOG("  INT1: Data Ready enabled\n\n");
+
+    // Collect 100 samples
+    CI_LOG("Collecting 100 samples...\n\n");
+
+    std::array<int16_t, 6> imu_data;
+    int sample_count = 0;
+    const int target_samples = 100;
+
+    while (sample_count < target_samples) {
+        if (data_ready) {
+            data_ready = false;
+
+            // Read raw IMU data
+            if (imu.ReadIMU6(imu_data) == 0) {
+                sample_count++;
+
+                // Print every 5th sample
+                if (sample_count % 5 == 0) {
+                    printf("Sample %d: ", sample_count);
+                    printf("Accel[%6d,%6d,%6d] ",
+                           imu_data[0], imu_data[1], imu_data[2]);
+                    printf("Gyro[%6d,%6d,%6d]\n",
+                           imu_data[3], imu_data[4], imu_data[5]);
+                }
+            }
+        }
+    }
+
+    CI_LOG("\n✓ Data collection complete\n");
+
+    // Disable interrupt
+    imu.DisableDataReadyInt1();
+    detachInterrupt(digitalPinToInterrupt(BoardConfig::imu.int_pin));
+
+    CI_LOG("\n=== Test Complete ===\n");
+    CI_LOG("*STOP*\n");
+}
+
+void loop() {
+    // Nothing to do
+}
+
+/* --------------------------------------------------------------------------------------
+ *  libPrintf putchar_ implementation for RTT/Serial routing
+ * -------------------------------------------------------------------------------------- */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void putchar_(char c) {
+#ifdef USE_RTT
+    char buf[2] = {c, '\0'};
+    SEGGER_RTT_WriteString(0, buf);
+#else
+    Serial.print(c);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/imu/examples/imu-raw-data-registers/imu-raw-data-registers.ino
+++ b/libraries/imu/examples/imu-raw-data-registers/imu-raw-data-registers.ino
@@ -84,7 +84,27 @@ void setup() {
         CI_LOG("*STOP*\n");
         while (1) delay(1000);
     }
-    CI_LOG("✓ IMU initialized successfully\n\n");
+    CI_LOG("✓ IMU initialized successfully\n");
+
+    // Detect chip type
+    IMU::ChipType chip = imu.GetChipType();
+    const char* chip_name = "UNKNOWN";
+    switch (chip) {
+        case IMU::ChipType::ICM42688_P: chip_name = "ICM-42688-P"; break;
+        case IMU::ChipType::MPU_6000:   chip_name = "MPU-6000"; break;
+        case IMU::ChipType::MPU_9250:   chip_name = "MPU-9250"; break;
+        default: break;
+    }
+    printf("Detected chip: %s (0x%02X)\n", chip_name, static_cast<uint8_t>(chip));
+
+    // Verify chip is supported by this library version
+    if (chip != IMU::ChipType::ICM42688_P) {
+        CI_LOG("ERROR: This library currently only supports ICM-42688-P!\n");
+        printf("Detected: %s (0x%02X)\n", chip_name, static_cast<uint8_t>(chip));
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+    CI_LOG("\n");
 
     // Configure IMU for interrupt-driven operation
     CI_LOG("Configuring IMU...\n");

--- a/libraries/imu/examples/imu-selftest/imu-selftest.ino
+++ b/libraries/imu/examples/imu-selftest/imu-selftest.ino
@@ -100,18 +100,16 @@ void setup() {
     }
 
     // Display bias values (converted to physical units)
-    float gyro_sens = imu.GetGyroSensitivity();
-    float accel_sens = imu.GetAccelSensitivity();
-
+    // Note: Bias values from get_st_bias are scaled by 2^16
     CI_LOG("=== Bias Values ===\n");
     printf("Gyro Bias (dps):  x=%.6f, y=%.6f, z=%.6f\n",
-           bias[0] / gyro_sens,
-           bias[1] / gyro_sens,
-           bias[2] / gyro_sens);
+           (float)bias[0] / (float)(1 << 16),
+           (float)bias[1] / (float)(1 << 16),
+           (float)bias[2] / (float)(1 << 16));
     printf("Accel Bias (g):   x=%.6f, y=%.6f, z=%.6f\n\n",
-           bias[3] / accel_sens,
-           bias[4] / accel_sens,
-           bias[5] / accel_sens);
+           (float)bias[3] / (float)(1 << 16),
+           (float)bias[4] / (float)(1 << 16),
+           (float)bias[5] / (float)(1 << 16));
 
     CI_LOG("=== Test Complete ===\n");
     CI_LOG("*STOP*\n");

--- a/libraries/imu/examples/imu-selftest/imu-selftest.ino
+++ b/libraries/imu/examples/imu-selftest/imu-selftest.ino
@@ -68,7 +68,27 @@ void setup() {
         CI_LOG("*STOP*\n");
         while (1) delay(1000);
     }
-    CI_LOG("✓ IMU initialized successfully\n\n");
+    CI_LOG("✓ IMU initialized successfully\n");
+
+    // Detect chip type
+    IMU::ChipType chip = imu.GetChipType();
+    const char* chip_name = "UNKNOWN";
+    switch (chip) {
+        case IMU::ChipType::ICM42688_P: chip_name = "ICM-42688-P"; break;
+        case IMU::ChipType::MPU_6000:   chip_name = "MPU-6000"; break;
+        case IMU::ChipType::MPU_9250:   chip_name = "MPU-9250"; break;
+        default: break;
+    }
+    printf("Detected chip: %s (0x%02X)\n", chip_name, static_cast<uint8_t>(chip));
+
+    // Verify chip is supported by this library version
+    if (chip != IMU::ChipType::ICM42688_P) {
+        CI_LOG("ERROR: This library currently only supports ICM-42688-P!\n");
+        printf("Detected: %s (0x%02X)\n", chip_name, static_cast<uint8_t>(chip));
+        CI_LOG("*STOP*\n");
+        while (1) delay(1000);
+    }
+    CI_LOG("\n");
 
     // Run self-test
     CI_LOG("Running manufacturer self-test...\n");

--- a/libraries/imu/library.properties
+++ b/libraries/imu/library.properties
@@ -1,0 +1,10 @@
+name=IMU
+version=1.0.0
+author=geosmall
+maintainer=geosmall
+sentence=High-level wrapper for InvenSense IMU sensors (ICM-42688-P, MPU-6000, MPU-9250)
+paragraph=Provides a unified C++ interface for InvenSense IMU sensors using manufacturer drivers. Currently supports ICM-42688-P with planned support for MPU-6000 and MPU-9250.
+category=Sensors
+url=https://github.com/geosmall/Arduino_dev
+architectures=stm32
+depends=ICM42688P

--- a/libraries/imu/src/IMU.cpp
+++ b/libraries/imu/src/IMU.cpp
@@ -1,0 +1,382 @@
+#include "IMU.h"
+#include "stm32yyxx_ll_system.h"  // For DWT cycle counter
+
+// External symbols needed by TDK driver
+extern "C" {
+    void inv_disable_irq(void);
+    void inv_enable_irq(void);
+    uint64_t inv_timer_get_counter(unsigned timer_num);
+    void inv_delay_us(uint32_t us);
+}
+
+// IRQ nesting counter
+static uint32_t sDisableIntCount = 0;
+
+void inv_disable_irq(void)
+{
+    if (sDisableIntCount == 0) {
+        __disable_irq();
+    }
+    sDisableIntCount++;
+}
+
+void inv_enable_irq(void)
+{
+    sDisableIntCount--;
+    if (sDisableIntCount == 0) {
+        __enable_irq();
+    }
+}
+
+uint64_t inv_timer_get_counter(unsigned timer_num)
+{
+    (void)timer_num;
+    return micros();
+}
+
+void inv_delay_us(uint32_t us)
+{
+    delayMicroseconds(us);
+}
+
+// ============================================================================
+// IMU Class Implementation
+// ============================================================================
+
+IMU::IMU()
+{
+    // Initialize DWT ticks per microsecond
+    us_ticks_ = SystemCoreClock / 1000000;
+}
+
+IMU::Result IMU::Init(SPIClass& spi, uint32_t cs_pin, uint32_t spi_freq_hz)
+{
+    // Store SPI reference and configuration
+    p_spi_ = &spi;
+    cs_pin_ = cs_pin;
+    spi_freq_hz_ = spi_freq_hz;
+    cs_pin_name_ = digitalPinToPinName(cs_pin);
+
+    // Initialize CS pin
+    pinMode(cs_pin_, OUTPUT);
+    digitalWrite(cs_pin_, HIGH);
+
+    // Initialize SPI
+    p_spi_->begin();
+
+    // Set up the TDK driver transport layer
+    driver_.transport.context = this;  // Store this pointer for callbacks
+    driver_.transport.read_reg = spiReadRegs;
+    driver_.transport.write_reg = spiWriteRegs;
+    driver_.transport.configure = spiConfigure;
+    driver_.transport.serif.context = this;
+    driver_.transport.serif.serif_type = ICM426XX_UI_SPI4;
+    driver_.transport.serif.is_spi = 1;
+
+    // Initialize the TDK high-level driver
+    int rc = inv_icm426xx_init(&driver_, &driver_.transport.serif, DriverEventCb);
+    if (rc != 0) {
+        return Result::ERR;
+    }
+
+    // Check WHO_AM_I
+    uint8_t who_am_i = 0;
+    rc = inv_icm426xx_get_who_am_i(&driver_, &who_am_i);
+    if (rc != 0 || who_am_i != ICM_WHOAMI) {
+        return Result::ERR;
+    }
+
+    initialized_ = true;
+    return Result::OK;
+}
+
+IMU::Result IMU::ConfigureInvDevice(AccelFS acc_fsr_g, GyroFS gyr_fsr_dps,
+                                     AccelODR acc_freq, GyroODR gyr_freq)
+{
+    if (!initialized_) {
+        return Result::ERR;
+    }
+
+    int rc = 0;
+
+    // Set FSR
+    rc |= inv_icm426xx_set_accel_fsr(&driver_, static_cast<ICM426XX_ACCEL_CONFIG0_FS_SEL_t>(acc_fsr_g));
+    rc |= inv_icm426xx_set_gyro_fsr(&driver_, static_cast<ICM426XX_GYRO_CONFIG0_FS_SEL_t>(gyr_fsr_dps));
+
+    // Set ODR
+    rc |= inv_icm426xx_set_accel_frequency(&driver_, static_cast<ICM426XX_ACCEL_CONFIG0_ODR_t>(acc_freq));
+    rc |= inv_icm426xx_set_gyro_frequency(&driver_, static_cast<ICM426XX_GYRO_CONFIG0_ODR_t>(gyr_freq));
+
+    // Update sensitivity values
+    rc |= inv_icm426xx_get_accel_fsr(&driver_, reinterpret_cast<ICM426XX_ACCEL_CONFIG0_FS_SEL_t*>(&acc_fsr_g));
+    rc |= inv_icm426xx_get_gyro_fsr(&driver_, reinterpret_cast<ICM426XX_GYRO_CONFIG0_FS_SEL_t*>(&gyr_fsr_dps));
+
+    // Calculate sensitivity from FSR
+    switch (acc_fsr_g) {
+        case gpm2:  accel_sensitivity_ = 16384.0f; break;
+        case gpm4:  accel_sensitivity_ = 8192.0f; break;
+        case gpm8:  accel_sensitivity_ = 4096.0f; break;
+        case gpm16: accel_sensitivity_ = 2048.0f; break;
+    }
+
+    switch (gyr_fsr_dps) {
+        case dps250:  gyro_sensitivity_ = 1311.0f; break;
+        case dps500:  gyro_sensitivity_ = 655.0f; break;
+        case dps1000: gyro_sensitivity_ = 328.0f; break;
+        case dps2000: gyro_sensitivity_ = 164.0f; break;
+    }
+
+    return (rc == 0) ? Result::OK : Result::ERR;
+}
+
+int IMU::Reset()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_soft_reset(&driver_);
+}
+
+int IMU::SetPwrState(PwrState state)
+{
+    if (!initialized_) return -1;
+
+    if (state == POWER_ON) {
+        return inv_icm426xx_enable_accel_low_noise_mode(&driver_) |
+               inv_icm426xx_enable_gyro_low_noise_mode(&driver_);
+    } else {
+        return inv_icm426xx_disable_accel(&driver_) |
+               inv_icm426xx_disable_gyro(&driver_);
+    }
+}
+
+int IMU::EnableAccelLNMode()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_enable_accel_low_noise_mode(&driver_);
+}
+
+int IMU::DisableAccel()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_disable_accel(&driver_);
+}
+
+int IMU::EnableGyroLNMode()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_enable_gyro_low_noise_mode(&driver_);
+}
+
+int IMU::DisableGyro()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_disable_gyro(&driver_);
+}
+
+int IMU::SetAccelODR(AccelODR frequency)
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_set_accel_frequency(&driver_, static_cast<ICM426XX_ACCEL_CONFIG0_ODR_t>(frequency));
+}
+
+int IMU::SetGyroODR(GyroODR frequency)
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_set_gyro_frequency(&driver_, static_cast<ICM426XX_GYRO_CONFIG0_ODR_t>(frequency));
+}
+
+int IMU::SetAccelFSR(AccelFS fsr)
+{
+    if (!initialized_) return -1;
+    int rc = inv_icm426xx_set_accel_fsr(&driver_, static_cast<ICM426XX_ACCEL_CONFIG0_FS_SEL_t>(fsr));
+
+    // Update sensitivity
+    if (rc == 0) {
+        switch (fsr) {
+            case gpm2:  accel_sensitivity_ = 16384.0f; break;
+            case gpm4:  accel_sensitivity_ = 8192.0f; break;
+            case gpm8:  accel_sensitivity_ = 4096.0f; break;
+            case gpm16: accel_sensitivity_ = 2048.0f; break;
+        }
+    }
+    return rc;
+}
+
+int IMU::SetGyroFSR(GyroFS fsr)
+{
+    if (!initialized_) return -1;
+    int rc = inv_icm426xx_set_gyro_fsr(&driver_, static_cast<ICM426XX_GYRO_CONFIG0_FS_SEL_t>(fsr));
+
+    // Update sensitivity
+    if (rc == 0) {
+        switch (fsr) {
+            case dps250:  gyro_sensitivity_ = 1311.0f; break;
+            case dps500:  gyro_sensitivity_ = 655.0f; break;
+            case dps1000: gyro_sensitivity_ = 328.0f; break;
+            case dps2000: gyro_sensitivity_ = 164.0f; break;
+        }
+    }
+    return rc;
+}
+
+int IMU::EnableDataReadyInt1()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_enable_accel_gyro_data_ready_int1(&driver_);
+}
+
+int IMU::DisableDataReadyInt1()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_disable_accel_gyro_data_ready_int1(&driver_);
+}
+
+int IMU::RunSelfTest(int* result, std::array<int, 6>* bias)
+{
+    if (!initialized_) return -1;
+
+    if (bias != nullptr) {
+        return inv_icm426xx_run_selftest(&driver_, result, bias->data());
+    } else {
+        return inv_icm426xx_run_selftest(&driver_, result, nullptr);
+    }
+}
+
+int IMU::ReadDataFromRegisters()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_get_data_from_registers(&driver_);
+}
+
+int IMU::ReadIMU6(std::array<int16_t, 6>& buf)
+{
+    if (!initialized_) return -1;
+
+    uint8_t raw_data[NUM_DATA_BYTES];
+    int rc = 0;
+
+    // Read all 12 bytes (6 accel + 6 gyro) at once
+    SelectDevice();
+
+    // Send read command for ACCEL_DATA_X1 register
+    uint8_t reg_addr = MPUREG_ACCEL_DATA_X1_UI | 0x80;  // Set read bit
+    p_spi_->beginTransaction(SPISettings(spi_freq_hz_, MSBFIRST, SPI_MODE0));
+    p_spi_->transfer(reg_addr);
+
+    // Read data
+    for (uint32_t i = 0; i < NUM_DATA_BYTES; i++) {
+        raw_data[i] = p_spi_->transfer(0xFF);
+    }
+
+    p_spi_->endTransaction();
+    DeselectDevice();
+
+    // Convert to int16_t
+    buf[0] = (int16_t)((raw_data[0] << 8) | raw_data[1]);   // Accel X
+    buf[1] = (int16_t)((raw_data[2] << 8) | raw_data[3]);   // Accel Y
+    buf[2] = (int16_t)((raw_data[4] << 8) | raw_data[5]);   // Accel Z
+    buf[3] = (int16_t)((raw_data[6] << 8) | raw_data[7]);   // Gyro X
+    buf[4] = (int16_t)((raw_data[8] << 8) | raw_data[9]);   // Gyro Y
+    buf[5] = (int16_t)((raw_data[10] << 8) | raw_data[11]); // Gyro Z
+
+    return rc;
+}
+
+int IMU::ReadDataFromFifo()
+{
+    if (!initialized_) return -1;
+    return inv_icm426xx_get_data_from_fifo(&driver_);
+}
+
+void IMU::SetSensorEventCallback(void (*userCb)(inv_icm426xx_sensor_event_t *event))
+{
+    user_event_cb_ = userCb;
+}
+
+// ============================================================================
+// Private Methods
+// ============================================================================
+
+void IMU::DelayNs(uint32_t delay_ns)
+{
+    const uint32_t start = DWT->CYCCNT;
+    const uint32_t ticks = (delay_ns * us_ticks_) / 1000;
+    while ((DWT->CYCCNT - start) < ticks) {}
+}
+
+void IMU::SelectDevice()
+{
+    digitalWriteFast(cs_pin_name_, LOW);
+    DelayNs(SETUP_TIME_NS);
+}
+
+void IMU::DeselectDevice()
+{
+    DelayNs(HOLD_TIME_NS);
+    digitalWriteFast(cs_pin_name_, HIGH);
+}
+
+void IMU::DriverEventCb(inv_icm426xx_sensor_event_t *event)
+{
+    // Get IMU instance from context
+    IMU* imu = static_cast<IMU*>(event->sensor_mask);  // TDK driver stores context here
+
+    if (imu && imu->user_event_cb_) {
+        imu->user_event_cb_(event);
+    }
+}
+
+// ============================================================================
+// TDK Transport Layer Callbacks
+// ============================================================================
+
+int IMU::spiReadRegs(struct inv_icm426xx_serif *serif,
+                     uint8_t reg,
+                     uint8_t *buf,
+                     uint32_t len)
+{
+    IMU* imu = static_cast<IMU*>(serif->context);
+    if (!imu || !imu->p_spi_) return -1;
+
+    imu->SelectDevice();
+
+    imu->p_spi_->beginTransaction(SPISettings(imu->spi_freq_hz_, MSBFIRST, SPI_MODE0));
+    imu->p_spi_->transfer(reg | 0x80);  // Set read bit
+
+    for (uint32_t i = 0; i < len; i++) {
+        buf[i] = imu->p_spi_->transfer(0xFF);
+    }
+
+    imu->p_spi_->endTransaction();
+    imu->DeselectDevice();
+
+    return 0;
+}
+
+int IMU::spiWriteRegs(struct inv_icm426xx_serif *serif,
+                      uint8_t reg,
+                      const uint8_t *buf,
+                      uint32_t len)
+{
+    IMU* imu = static_cast<IMU*>(serif->context);
+    if (!imu || !imu->p_spi_) return -1;
+
+    for (uint32_t i = 0; i < len; i++) {
+        imu->SelectDevice();
+
+        imu->p_spi_->beginTransaction(SPISettings(imu->spi_freq_hz_, MSBFIRST, SPI_MODE0));
+        imu->p_spi_->transfer(reg + i);  // Write bit is 0
+        imu->p_spi_->transfer(buf[i]);
+        imu->p_spi_->endTransaction();
+
+        imu->DeselectDevice();
+    }
+
+    return 0;
+}
+
+int IMU::spiConfigure(struct inv_icm426xx_serif *serif)
+{
+    // No-op for Arduino - SPI already configured
+    (void)serif;
+    return 0;
+}

--- a/libraries/imu/src/IMU.cpp
+++ b/libraries/imu/src/IMU.cpp
@@ -231,6 +231,27 @@ int IMU::SetGyroFSR(GyroFS fsr)
     return rc;
 }
 
+IMU::ChipType IMU::GetChipType()
+{
+    if (!initialized_) {
+        return ChipType::UNKNOWN;
+    }
+
+    uint8_t who_am_i = 0;
+    int rc = inv_icm426xx_get_who_am_i(&driver_, &who_am_i);
+    if (rc != 0) {
+        return ChipType::UNKNOWN;
+    }
+
+    // Map WHO_AM_I value to ChipType enum
+    switch (who_am_i) {
+        case 0x47: return ChipType::ICM42688_P;
+        case 0x68: return ChipType::MPU_6000;
+        case 0x71: return ChipType::MPU_9250;
+        default:   return ChipType::UNKNOWN;
+    }
+}
+
 int IMU::EnableDataReadyInt1()
 {
     if (!initialized_) return -1;

--- a/libraries/imu/src/IMU.h
+++ b/libraries/imu/src/IMU.h
@@ -1,0 +1,344 @@
+#ifndef IMU_H
+#define IMU_H
+
+#include <cstdint>
+#include <cstdio>
+#include <array>
+#include <SPI.h>
+#include <Arduino.h>
+
+// TDK high-level driver API (includes Icm426xxTransport.h references)
+extern "C" {
+#include "icm42688p.h"
+}
+
+/*
+ * ============================================================
+ * Accelerometer Sensitivity (LSB per g)
+ * ------------------------------------------------------------
+ * The scale factor depends on the full-scale range (FSR),
+ * which is configured in the ACCEL_CONFIG0 register.
+ *
+ *  |  Accel Range (g)  | Sensitivity (LSB/g)  |
+ *  |-------------------|----------------------|
+ *  |       ±16g        |         2048         |
+ *  |        ±8g        |         4096         |
+ *  |        ±4g        |         8192         |
+ *  |        ±2g        |        16384         |
+ *
+ * ============================================================
+ * Gyroscope Sensitivity (LSB per dps)
+ * ------------------------------------------------------------
+ * The scale factor depends on the full-scale range (FSR),
+ * which is configured in the GYRO_CONFIG0 register.
+ *
+ *  |  Gyro Range (dps) | Sensitivity (LSB/dps) |
+ *  |-------------------|-----------------------|
+ *  |      ±2000        |          164          |
+ *  |      ±1000        |          328          |
+ *  |      ±500         |         655          |
+ *  |      ±250         |         1311          |
+ *
+ * ============================================================
+ * Note:
+ * - The raw sensor output is a signed 16-bit integer.
+ * - To convert raw values to physical units:
+ *      Accel (g)  = raw_value / sensitivity (LSB/g)
+ *      Gyro (dps) = raw_value / sensitivity (LSB/dps)
+ * - Make sure the FSR is correctly configured before using
+ *   the sensitivity values in calculations.
+ * ============================================================
+ */
+
+/**
+ * @brief High-level C++ wrapper for InvenSense IMU sensors
+ *        Currently supports ICM-42688-P, designed for easy extension
+ *        to MPU-6000, MPU-9250, and other InvenSense parts.
+ */
+class IMU
+{
+public:
+
+    enum PwrState : bool
+    {
+        POWER_OFF = false,
+        POWER_ON = true,
+    };
+
+    enum AccelFS : uint8_t
+    {
+        gpm16 = ICM426XX_ACCEL_CONFIG0_FS_SEL_16g, // (default)
+        gpm8 = ICM426XX_ACCEL_CONFIG0_FS_SEL_8g,
+        gpm4 = ICM426XX_ACCEL_CONFIG0_FS_SEL_4g,
+        gpm2 = ICM426XX_ACCEL_CONFIG0_FS_SEL_2g
+    };
+
+    enum GyroFS : uint8_t
+    {
+        dps2000 = ICM426XX_GYRO_CONFIG0_FS_SEL_2000dps, // (default)
+        dps1000 = ICM426XX_GYRO_CONFIG0_FS_SEL_1000dps,
+        dps500 = ICM426XX_GYRO_CONFIG0_FS_SEL_500dps,
+        dps250 = ICM426XX_GYRO_CONFIG0_FS_SEL_250dps
+    };
+
+    enum AccelODR : uint8_t
+    {
+        accel_odr500 = ICM426XX_ACCEL_CONFIG0_ODR_500_HZ, /*!< 500 Hz (2 ms)*/
+        accel_odr1k = ICM426XX_ACCEL_CONFIG0_ODR_1_KHZ, /*!< 1 KHz (1 ms)*/
+        accel_odr2k = ICM426XX_ACCEL_CONFIG0_ODR_2_KHZ, /*!< 2 KHz (500 us)*/
+        accel_odr4k = ICM426XX_ACCEL_CONFIG0_ODR_4_KHZ, /*!< 4 KHz (250 us)*/
+        accel_odr8k = ICM426XX_ACCEL_CONFIG0_ODR_8_KHZ, /*!< 8 KHz (125 us)*/
+    };
+
+    enum GyroODR : uint8_t
+    {
+        gyr_odr500 = ICM426XX_GYRO_CONFIG0_ODR_500_HZ, /*!< 500 Hz (2 ms)*/
+        gyr_odr1k = ICM426XX_GYRO_CONFIG0_ODR_1_KHZ, /*!< 1 KHz (1 ms)*/
+        gyr_odr2k = ICM426XX_GYRO_CONFIG0_ODR_2_KHZ, /*!< 2 KHz (500 us)*/
+        gyr_odr4k = ICM426XX_GYRO_CONFIG0_ODR_4_KHZ, /*!< 4 KHz (250 us)*/
+        gyr_odr8k = ICM426XX_GYRO_CONFIG0_ODR_8_KHZ, /*!< 8 KHz (125 us)*/
+    };
+
+    enum class Result
+    {
+        OK,
+        ERR,
+    };
+
+    /**
+     * @brief Construct an IMU object.
+     */
+    IMU();
+
+    /**
+     * @brief Initialize the IMU hardware and driver with Arduino SPI.
+     * @param spi Reference to Arduino SPIClass instance
+     * @param cs_pin Chip select pin number
+     * @param spi_freq_hz SPI frequency in Hz
+     * @return IMU::Result::OK on success, IMU::Result::ERR on failure.
+     */
+    Result Init(SPIClass& spi, uint32_t cs_pin, uint32_t spi_freq_hz);
+
+    /**
+     * @brief Configure the device full scales and output frequencies.
+     * @param acc_fsr_g Accelerometer full-scale range.
+     * @param gyr_fsr_dps Gyroscope full-scale range.
+     * @param acc_freq Accelerometer Output Data Rate.
+     * @param gyr_freq Gyroscope Output Data Rate.
+     * @return IMU::Result::OK on success, IMU::Result::ERR on failure.
+     */
+    Result ConfigureInvDevice(AccelFS acc_fsr_g, GyroFS gyr_fsr_dps, AccelODR acc_freq, GyroODR gyr_freq);
+
+    /**
+     * @brief Perform a soft reset of the device.
+     * @return 0 on success, negative error code on failure.
+     */
+    int Reset();
+
+    /**
+     * @brief Set power state of device on or off.
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetPwrState(PwrState state);
+
+    /**
+     * @brief Enable accelerometer in Low Noise mode.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableAccelLNMode();
+
+    /**
+     * @brief Disable accelerometer.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableAccel();
+
+    /**
+     * @brief Enable gyroscope in Low Noise mode.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableGyroLNMode();
+
+    /**
+     * @brief Disable gyroscope.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableGyro();
+
+    /**
+     * @brief Configure the accelerometer Output Data Rate.
+     * @param frequency e.g. ICM426XX_ACCEL_CONFIG0_ODR_1_KHZ
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetAccelODR(AccelODR frequency);
+
+    /**
+     * @brief Configure the gyroscope Output Data Rate.
+     * @param frequency e.g. ICM426XX_GYRO_CONFIG0_ODR_1_KHZ
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetGyroODR(GyroODR frequency);
+
+    /**
+     * @brief Set the accelerometer full-scale range.
+     * @param fsr e.g. ICM426XX_ACCEL_CONFIG0_FS_SEL_4g
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetAccelFSR(AccelFS fsr);
+
+    /**
+     * @brief Set the gyroscope full-scale range.
+     * @param fsr e.g. ICM426XX_GYRO_CONFIG0_FS_SEL_2000dps
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetGyroFSR(GyroFS fsr);
+
+    /**
+     * @brief Get the accelerometer full-scale range.
+     * @return Accel sensitivity value (updated upon change to FS value).
+     */
+    float GetAccelSensitivity() const { return accel_sensitivity_; }
+
+    /**
+     * @brief Get the gyroscope full-scale range.
+     * @return Gyro sensitivity value (updated upon change to FS value).
+     */
+    float GetGyroSensitivity()  const { return gyro_sensitivity_; }
+
+    /**
+     * @brief Enable the data ready interrupt on INT1 pin.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableDataReadyInt1();
+
+    /**
+     * @brief Disable the data ready interrupt on INT1 pin.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableDataReadyInt1();
+
+    /**
+     * @brief Perform IMU self-test.
+     * @param result (ACCEL_SUCCESS<<1 | GYRO_SUCCESS), 3 means both passed.
+     * @param bias Optional array of 6 int, stores bias values (3 for accel, 3 for gyro).
+     * @return 0 on success, negative error code on failure.
+     */
+    int RunSelfTest(int* result, std::array<int, 6>* bias = nullptr);
+
+    /**
+     * @brief Read sensor data from registers (bypassing FIFO).
+     * @return 0 on success, negative error code on failure.
+     */
+    int ReadDataFromRegisters();
+
+    /**
+     * @brief Read Acc/Gyro data direct from registers (bypassing transport read for speed).
+     * @param buf filled with Accel X Y Z followed by Gyro X Y Z
+     * @return 0 on success, negative error code on failure.
+     */
+    int ReadIMU6(std::array<int16_t, 6>& buf);
+
+    /**
+     * @brief Read sensor data from FIFO.
+     * @return Number of FIFO packets read on success, or negative error code on failure.
+     */
+    int ReadDataFromFifo();
+
+    /**
+     * @brief Provide a user callback for sensor events. This is called by the TDK driver
+     *        whenever data is read from registers or FIFO.
+     *
+     * @param userCb The function pointer for your callback, or nullptr to disable.
+     */
+    void SetSensorEventCallback(void (*userCb)(inv_icm426xx_sensor_event_t *event));
+
+    // Define maximum read and write sizes for IMU as private static constants
+    static constexpr uint32_t IMU_MAX_READ = 255;
+    static constexpr uint32_t IMU_MAX_WRITE = 255;
+    static constexpr uint32_t NUM_DATA_BYTES = (ACCEL_DATA_SIZE + GYRO_DATA_SIZE);
+
+private:
+    /**
+     * @brief TDK driver instance for this IMU.
+     * IMPORTANT: The driver struct must have a `struct inv_icm426xx_transport`
+     * as its first field.
+     */
+    struct inv_icm426xx driver_{};
+
+    /**
+     * @brief Pointer to the Arduino SPI instance used for IMU SPI transactions.
+     * Initialized to null, to be bound in Init()
+     */
+    SPIClass* p_spi_ = nullptr;
+
+    /**
+     * @brief SPI frequency in Hz
+     */
+    uint32_t spi_freq_hz_ = 0;
+
+    bool initialized_ = false;
+
+    /**
+     * @brief IMU chip select pin (using software driven CS).
+     */
+    uint32_t cs_pin_;
+    PinName cs_pin_name_;  // For fast digitalWriteFast()
+
+    float accel_sensitivity_{-1.0f};
+    float gyro_sensitivity_{-1.0f};
+
+    // CS->CLK delay, MPU6000 - 8ns
+    // CS->CLK delay, ICM42688P - 39ns
+    static constexpr uint32_t SETUP_TIME_NS  = 39;   // For ICM42688P
+    static constexpr uint32_t HOLD_TIME_NS   = 18;   // For ICM42688P
+
+    // DWT ticks per microsecond for timing delays
+    uint32_t us_ticks_;
+
+    void SelectDevice();
+
+    void DeselectDevice();
+
+    void DelayNs(uint32_t delay_ns);
+
+    /**
+     * @brief The TDK driver calls this function when new sensor data arrives.
+     */
+    static void DriverEventCb(inv_icm426xx_sensor_event_t *event);
+
+    /**
+     * @brief User-defined callback pointer (per-instance via driver_.transport.context)
+     */
+    void (*user_event_cb_)(inv_icm426xx_sensor_event_t *event) = nullptr;
+
+    // -------------------------------------------------------------------------
+    // The TDK transport layer requires read_reg, write_reg, configure
+    // function pointers with the following signatures:
+    //   int foo(struct inv_icm426xx_serif *serif, uint8_t reg, ..., uint32_t len);
+    // We'll implement them as static methods. We retrieve the IMU instance via
+    //   (IMU*)serif->context.
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief  TDK read callback for SPI-based register reads.
+     */
+    static int spiReadRegs(struct inv_icm426xx_serif *serif,
+                           uint8_t                    reg,
+                           uint8_t                   *buf,
+                           uint32_t                   len);
+
+    /**
+     * @brief  TDK write callback for SPI-based register writes.
+     */
+    static int spiWriteRegs(struct inv_icm426xx_serif *serif,
+                            uint8_t                    reg,
+                            const uint8_t             *buf,
+                            uint32_t                   len);
+
+    /**
+     * @brief  TDK configure callback, if used. Often a no-op for many systems.
+     */
+    static int spiConfigure(struct inv_icm426xx_serif *serif);
+};
+
+#endif // IMU_H

--- a/libraries/imu/src/IMU.h
+++ b/libraries/imu/src/IMU.h
@@ -105,6 +105,14 @@ public:
         ERR,
     };
 
+    enum class ChipType : uint8_t
+    {
+        UNKNOWN = 0x00,
+        ICM42688_P = 0x47,
+        MPU_6000 = 0x68,
+        MPU_9250 = 0x71,
+    };
+
     /**
      * @brief Construct an IMU object.
      */
@@ -204,6 +212,12 @@ public:
      * @return Gyro sensitivity value (updated upon change to FS value).
      */
     float GetGyroSensitivity()  const { return gyro_sensitivity_; }
+
+    /**
+     * @brief Get the detected chip type via WHO_AM_I register.
+     * @return ChipType enum value (UNKNOWN, ICM42688P, MPU6000, MPU9250).
+     */
+    ChipType GetChipType();
 
     /**
      * @brief Enable the data ready interrupt on INT1 pin.

--- a/libraries/imu/src/IMU.h
+++ b/libraries/imu/src/IMU.h
@@ -260,10 +260,13 @@ public:
 private:
     /**
      * @brief TDK driver instance for this IMU.
-     * IMPORTANT: The driver struct must have a `struct inv_icm426xx_transport`
-     * as its first field.
      */
     struct inv_icm426xx driver_{};
+
+    /**
+     * @brief TDK serif (serial interface) structure for communication callbacks.
+     */
+    struct inv_icm426xx_serif serif_{};
 
     /**
      * @brief Pointer to the Arduino SPI instance used for IMU SPI transactions.

--- a/libraries/imu/src/imu.h
+++ b/libraries/imu/src/imu.h
@@ -1,0 +1,337 @@
+#ifndef IMU_H
+#define IMU_H
+
+#include <cstdint>
+#include <cstdio>
+#include <array>
+#include "uvos.h"
+
+// TDK high-level driver API (includes Icm426xxTransport.h references)
+extern "C" {
+#include "icm42688p.h"
+}
+
+/*
+ * ============================================================
+ * Accelerometer Sensitivity (LSB per g)
+ * ------------------------------------------------------------
+ * The scale factor depends on the full-scale range (FSR),
+ * which is configured in the ACCEL_CONFIG0 register.
+ *
+ *  |  Accel Range (g)  | Sensitivity (LSB/g)  |
+ *  |-------------------|----------------------|
+ *  |       ±16g        |         2048         |
+ *  |        ±8g        |         4096         |
+ *  |        ±4g        |         8192         |
+ *  |        ±2g        |        16384         |
+ *
+ * ============================================================
+ * Gyroscope Sensitivity (LSB per dps)
+ * ------------------------------------------------------------
+ * The scale factor depends on the full-scale range (FSR),
+ * which is configured in the GYRO_CONFIG0 register.
+ *
+ *  |  Gyro Range (dps) | Sensitivity (LSB/dps) |
+ *  |-------------------|-----------------------|
+ *  |      ±2000        |          164          |
+ *  |      ±1000        |          328          |
+ *  |      ±500         |          655          |
+ *  |      ±250         |         1311          |
+ *
+ * ============================================================
+ * Note:
+ * - The raw sensor output is a signed 16-bit integer.
+ * - To convert raw values to physical units:
+ *      Accel (g)  = raw_value / sensitivity (LSB/g)
+ *      Gyro (dps) = raw_value / sensitivity (LSB/dps)
+ * - Make sure the FSR is correctly configured before using
+ *   the sensitivity values in calculations.
+ * ============================================================
+ */
+
+// Use the uvos namespace to prevent having to type uvos:: before all calls
+using namespace uvos;
+
+namespace uvos {
+
+/**
+ * @brief A C++ wrapper around the TDK ICM-426xx high-level driver, adapted to
+ *        use your 'uvos::SpiHandle' and TDK's transport layer definitions.
+ */
+class IMU
+{
+public:
+
+    enum PwrState : bool
+    {
+        POWER_OFF = false,
+        POWER_ON = true,
+    };
+
+    enum AccelFS : uint8_t
+    {
+        gpm16 = ICM426XX_ACCEL_CONFIG0_FS_SEL_16g, // (default)
+        gpm8 = ICM426XX_ACCEL_CONFIG0_FS_SEL_8g,
+        gpm4 = ICM426XX_ACCEL_CONFIG0_FS_SEL_4g,
+        gpm2 = ICM426XX_ACCEL_CONFIG0_FS_SEL_2g
+    };
+
+    enum GyroFS : uint8_t
+    {
+        dps2000 = ICM426XX_GYRO_CONFIG0_FS_SEL_2000dps, // (default)
+        dps1000 = ICM426XX_GYRO_CONFIG0_FS_SEL_1000dps,
+        dps500 = ICM426XX_GYRO_CONFIG0_FS_SEL_500dps,
+        dps250 = ICM426XX_GYRO_CONFIG0_FS_SEL_250dps
+    };
+
+    enum AccelODR : uint8_t
+    {
+        accel_odr500 = ICM426XX_ACCEL_CONFIG0_ODR_500_HZ, /*!< 500 Hz (2 ms)*/
+        accel_odr1k = ICM426XX_ACCEL_CONFIG0_ODR_1_KHZ, /*!< 1 KHz (1 ms)*/
+        accel_odr2k = ICM426XX_ACCEL_CONFIG0_ODR_2_KHZ, /*!< 2 KHz (500 us)*/
+        accel_odr4k = ICM426XX_ACCEL_CONFIG0_ODR_4_KHZ, /*!< 4 KHz (250 us)*/
+        accel_odr8k = ICM426XX_ACCEL_CONFIG0_ODR_8_KHZ, /*!< 8 KHz (125 us)*/
+    };
+
+    enum GyroODR : uint8_t
+    {
+        gyr_odr500 = ICM426XX_GYRO_CONFIG0_ODR_500_HZ, /*!< 500 Hz (2 ms)*/
+        gyr_odr1k = ICM426XX_GYRO_CONFIG0_ODR_1_KHZ, /*!< 1 KHz (1 ms)*/
+        gyr_odr2k = ICM426XX_GYRO_CONFIG0_ODR_2_KHZ, /*!< 2 KHz (500 us)*/
+        gyr_odr4k = ICM426XX_GYRO_CONFIG0_ODR_4_KHZ, /*!< 4 KHz (250 us)*/
+        gyr_odr8k = ICM426XX_GYRO_CONFIG0_ODR_8_KHZ, /*!< 8 KHz (125 us)*/
+    };
+
+    enum class Result
+    {
+        OK,
+        ERR,
+    };
+
+    /**
+     * @brief Construct an IMU object bound to a particular SpiHandle.
+     */
+    IMU();
+
+    /**
+     * @brief Initialize the IMU hardware and driver.
+     * @return IMU::OK on success, IMU::ERR on failure.
+     */
+    Result Init(SpiHandle& spi);
+
+    /**
+     * @brief Configure the device full scales and output frequencies.
+     * @param acc_fsr_g Accelerometer full-scale range.
+     * @param gyr_fsr_dps Gyroscope full-scale range.
+     * @param acc_freq Accelerometer Output Data Rate.
+     * @param gyr_freq Gyroscope Output Data Rate.
+     * @return IMU::OK on success, IMU::ERR on failure.
+     */
+    Result ConfigureInvDevice(AccelFS acc_fsr_g, GyroFS gyr_fsr_dps, AccelODR acc_freq, GyroODR gyr_freq);
+
+    /**
+     * @brief Perform a soft reset of the device.
+     * @return 0 on success, negative error code on failure.
+     */
+    int Reset();
+
+    /**
+     * @brief Set power state of device on or off.
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetPwrState(PwrState state);
+
+    /**
+     * @brief Enable accelerometer in Low Noise mode.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableAccelLNMode();
+
+    /**
+     * @brief Disable accelerometer.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableAccel();
+
+    /**
+     * @brief Enable gyroscope in Low Noise mode.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableGyroLNMode();
+
+    /**
+     * @brief Disable gyroscope.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableGyro();
+
+    /**
+     * @brief Configure the accelerometer Output Data Rate.
+     * @param frequency e.g. ICM426XX_ACCEL_CONFIG0_ODR_1_KHZ
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetAccelODR(AccelODR frequency);
+
+    /**
+     * @brief Configure the gyroscope Output Data Rate.
+     * @param frequency e.g. ICM426XX_GYRO_CONFIG0_ODR_1_KHZ
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetGyroODR(GyroODR frequency);
+
+    /**
+     * @brief Set the accelerometer full-scale range.
+     * @param fsr e.g. ICM426XX_ACCEL_CONFIG0_FS_SEL_4g
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetAccelFSR(AccelFS fsr);
+
+    /**
+     * @brief Set the gyroscope full-scale range.
+     * @param fsr e.g. ICM426XX_GYRO_CONFIG0_FS_SEL_2000dps
+     * @return 0 on success, negative error code on failure.
+     */
+    int SetGyroFSR(GyroFS fsr);
+
+    /**
+     * @brief Get the accelerometer full-scale range.
+     * @return Accel sensitivity value (updated upon change to FS value).
+     */
+    float GetAccelSensitivity() const { return accel_sensitivity_; }
+
+    /**
+     * @brief Get the gyroscope full-scale range.
+     * @return Gyro sensitivity value (updated upon change to FS value).
+     */
+    float GetGyroSensitivity()  const { return gyro_sensitivity_; }
+
+    /**
+     * @brief Enable the data ready interrupt on INT1 pin.
+     * @return 0 on success, negative error code on failure.
+     */
+    int EnableDataReadyInt1();
+
+    /**
+     * @brief Enable the data ready interrupt on INT1 pin.
+     * @return 0 on success, negative error code on failure.
+     */
+    int DisableDataReadyInt1();
+
+    /**
+     * @brief Perform IMU self-test.
+     * @param result (ACCEL_SUCCESS<<1 | GYRO_SUCCESS), 3 means both passed.
+     * @param bias Optional array of 6 int, stores bias values (3 for accel, 3 for gyro).
+     * @return 0 on success, negative error code on failure.
+     */
+    // int RunSelfTest(int* result, int* bias = nullptr);
+    int RunSelfTest(int* result, std::array<int, 6>* bias = nullptr);
+
+    /**
+     * @brief Read sensor data from registers (bypassing FIFO).
+     * @return 0 on success, negative error code on failure.
+     */
+    int ReadDataFromRegisters();
+
+    /**
+     * @brief Read Acc/Gyro data direct from registers (bypassing transport read for speed).
+     * @param buf filled with Accel X Y Z followed by Gyro X Y Z
+     * @return 0 on success, negative error code on failure.
+     */
+    // int ReadIMU6(uint8_t *buf);
+    int ReadIMU6(std::array<int16_t, 6>& buf);
+
+    /**
+     * @brief Read sensor data from FIFO.
+     * @return Number of FIFO packets read on success, or negative error code on failure.
+     */
+    int ReadDataFromFifo();
+
+    /**
+     * @brief Provide a user callback for sensor events. This is called by the TDK driver
+     *        whenever data is read from registers or FIFO.
+     *
+     * @param userCb The function pointer for your callback, or nullptr to disable.
+     */
+    void SetSensorEventCallback(void (*userCb)(inv_icm426xx_sensor_event_t *event));
+
+    // Define maximum read and write sizes for IMU as private static constants
+    static constexpr uint32_t IMU_MAX_READ = 255;
+    static constexpr uint32_t IMU_MAX_WRITE = 255;
+    static constexpr uint32_t NUM_DATA_BYTES = (ACCEL_DATA_SIZE + GYRO_DATA_SIZE);
+
+private:
+    /**
+     * @brief TDK driver instance for this IMU.
+     * IMPORTANT: The driver struct must have a `struct inv_icm426xx_transport`
+     * as its first field.
+     */
+    struct inv_icm426xx driver_{};
+
+    /**
+     * @brief Pointer to the SPI handle used for IMU SPI transactions.
+     * Initialized to null, to be bound in Init()
+     */
+    SpiHandle* p_spi_ = nullptr;
+
+    bool initialized_ = false;
+
+    /**
+     * @brief IMU chip select pin (using software driven CS).
+     */
+    GPIO csPin_;
+
+    float accel_sensitivity_{-1.0f};
+    float gyro_sensitivity_{-1.0f};
+
+    // CS->CLK delay, MPU6000 - 8ns
+    // CS->CLK delay, ICM42688P - 39ns
+    static constexpr uint32_t SETUP_TIME_NS  = 39;   // For ICM42688P
+    static constexpr uint32_t HOLD_TIME_NS   = 18;   // For ICM42688P
+
+    void SelectDevice();
+
+    void DeselectDevice();
+
+    /**
+     * @brief The TDK driver calls this function when new sensor data arrives.
+     */
+    static void DriverEventCb(inv_icm426xx_sensor_event_t *event);
+
+    /**
+     * @brief User-defined callback pointer.
+     */
+    static void (*userEventCb_)(inv_icm426xx_sensor_event_t *event);
+
+    // -------------------------------------------------------------------------
+    // The TDK transport layer requires read_reg, write_reg, configure
+    // function pointers with the following signatures:
+    //   int foo(struct inv_icm426xx_serif *serif, uint8_t reg, ..., uint32_t len);
+    // We'll implement them as static methods. We retrieve the IMU instance via
+    //   (IMU*)serif->context.
+    // -------------------------------------------------------------------------
+
+    /**
+     * @brief  TDK read callback for SPI-based register reads.
+     */
+    static int spiReadRegs(struct inv_icm426xx_serif *serif,
+                           uint8_t                    reg,
+                           uint8_t                   *buf,
+                           uint32_t                   len);
+
+    /**
+     * @brief  TDK write callback for SPI-based register writes.
+     */
+    static int spiWriteRegs(struct inv_icm426xx_serif *serif,
+                            uint8_t                    reg,
+                            const uint8_t             *buf,
+                            uint32_t                   len);
+
+    /**
+     * @brief  TDK configure callback, if used. Often a no-op for many systems.
+     */
+    static int spiConfigure(struct inv_icm426xx_serif *serif);
+};
+
+} // namespace uvos
+
+#endif // IMU_H


### PR DESCRIPTION
  Adds high-level IMU wrapper library for InvenSense sensors, starting with ICM-42688-P.

  **Features:**
  - Phase 1-3 complete: Working ICM42688P implementation
  - Context-based design for multi-instance support
  - Interrupt-driven data acquisition
  - Chip detection framework (ICM42688_P, MPU_6000, MPU_9250)
  - 2 examples: imu-selftest, imu-raw-data-registers
  - Full HIL validation on NUCLEO_F411RE

  **Design:**
  - Arduino-compatible C++ wrapper over TDK InvenSense drivers
  - BoardConfig integration for multi-board support
  - Future-ready for MPU-6000 and MPU-9250 support
